### PR TITLE
Make work in node@4.

### DIFF
--- a/lib/store/store.js
+++ b/lib/store/store.js
@@ -15,7 +15,7 @@ function softAssert(message, test) {
         chalk.yellow(message)
     );
 
-    let trace = new Error(message);
+    var trace = new Error(message);
     console.log('\n\n', chalk.red(trace));
   }
 }


### PR DESCRIPTION
node@4 allows `let` and `const` but only when used in `'use strict';` mode.  I changed this `let` to a `var` (instead of adding `'use strict';`) to keep things consistent in this file/project.

I ran into this when testing ember-data under node@4. `ember serve` triggers:

```
Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
```